### PR TITLE
configuration was not a valid endpoint

### DIFF
--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -1,6 +1,5 @@
 {
     "base_url": "http://api.themoviedb.org/3/"
-  , "configuration" : "configuration"
   , "authentication" : {
         "requestToken" : "authentication/token/new"
       , "sessionId" : "authentication/session/new"


### PR DESCRIPTION
Hi! First off, thanks for this project. It's been a great help to me and is as simple and easy to use as it gets.

I noticed in the endpoints.json you have configuration listed as an endpoint, but it is not being automatically parsed for use. It's configured the same as the "authentication" data, but that is grabbed manually in code. After a search for where "configuration" might be used came up with nothing, I thought this might be an oversight. This request simply creates new GET endpoint and lets you gets configuration data easily by doing require('moviedb').configuration(function(err, res) { ... }); If this was not your intention for the API to be defined this way, or if there is an alternate way of getting at the TMDB configuration end point, please let me know.

Thanks,

Paul
