### PR TITLE
Uppercasing request type for superagent

### DIFF
--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -75,6 +75,7 @@ Object.keys(endpoints.methods).forEach(function(method){
 var execMethod = function(type, params, endpoint, fn){
   params = params || {};
   endpoint = endpoint.replace(':id', params.id);
+  type = type.toUpperCase();
   
   request(type, endpoints.base_url + endpoint)
   .query({api_key : this.api_key})


### PR DESCRIPTION
Methods that rely on GET were failing because superagent expects the request type to be uppercase, while in the endpoints.json they are lowercase. This was causing parameters to be dropped.
