### PR TITLE
Support custom base_url

### DIFF
--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -10,8 +10,8 @@ var request = require('superagent')
  * Exports the constructor
  */
 
-module.exports = function(api_key){
-  if(api_key) return new MovieDB(api_key);
+module.exports = function(api_key, base_url){
+  if(api_key) return new MovieDB(api_key, base_url);
   else throw new Error('Bad api key');
 };
 
@@ -19,8 +19,9 @@ module.exports = function(api_key){
  * Constructor
  */
 
-function MovieDB(api_key) {
+function MovieDB(api_key, base_url) {
   this.api_key = api_key;
+  if(base_url) endpoints.base_url = base_url;
   return this;
 }
 


### PR DESCRIPTION
The mock API server provided by [apiary.io](http://docs.themoviedb.apiary.io/), where the v3 api docs are hosted, is useful during development for testing and validating requests. By specifying a custom base_url, developers can use this endpoint during testing.
