### PR TITLE
added request queueing

### DIFF
--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -45,13 +45,14 @@ MovieDB.prototype.requestToken = function(fn){
     .get(endpoints.base_url  + endpoints.authentication.requestToken)
     .query({'api_key': self.api_key})
     .set('Accept', 'application/json')
-    .end(function(res){
-      if(!res.ok) return fn(res.error);
+    .end(function(err, res){
+      if (err) {
+        fn(err);
+        return;
+      }
       self.token = res.body;
       MovieDB.queue(self);
       fn();
-    }).on('error', function(error){
-      fn(error);
     });
   });
   this.token = true;

--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -153,12 +153,11 @@ var execMethod = function(type, params, endpoint, fn){
       req.query(params);
     else
       req.send(params);
-    req.end(function(res){
-      //
-      if(res.ok) {
-        fn(null, res.body);
+    req.end(function(err, res){
+      if (err) {
+        fn(err, null);
       } else {
-        fn(res.error, null);
+        fn(null, res.body);
       }
       MovieDB.requestCurrent -= 1;
       MovieDB.queue(self);

--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -26,26 +26,37 @@ function MovieDB(api_key, base_url) {
 }
 
 /*
+ * Rate Limits
+ */
+
+MovieDB.maxConcurrent = 20;
+MovieDB.maxDuration = 10000;
+MovieDB.maxRate = 40;
+
+/*
  * API auth
  */
 
 MovieDB.prototype.requestToken = function(fn){
   var self = this;
 
-  request
-  .get(endpoints.base_url  + endpoints.authentication.requestToken)
-  .query({'api_key': self.api_key})
-  .set('Accept', 'application/json')
-  .end(function(err, res){
-    if(err) {
-      fn(err);
-    } else {
-       self.token = res.body;
-       fn();
-    }
+  MovieDB.queue(this, function() {
+    request
+    .get(endpoints.base_url  + endpoints.authentication.requestToken)
+    .query({'api_key': self.api_key})
+    .set('Accept', 'application/json')
+    .end(function(res){
+      if(!res.ok) return fn(res.error);
+      self.token = res.body;
+      MovieDB.queue(self);
+      fn();
+    }).on('error', function(error){
+      fn(error);
+    });
   });
+  this.token = true;
 
-  return this;
+  return;
 };
 
 /*
@@ -66,36 +77,92 @@ Object.keys(endpoints.methods).forEach(function(method){
       if(!this.token || Date.now() > +new Date(this.token.expires_at)) {
         this.requestToken(function(err){
           if(err) return fn(err);
-          execMethod.call(self, met[m].method, params, met[m].resource, fn);
-        });    
-      } else {
-        execMethod.call(this, met[m].method, params, met[m].resource, fn);
-      } 
+        });
+      }
+      execMethod.call(this, met[m].method, params, met[m].resource, fn);
 
       return this;
     };
   });
 });
 
+/*
+ * Manage Queued requests
+ */
+
+MovieDB.requestTimes = [0];
+MovieDB.requestCurrent = 0;
+MovieDB.requestQueue = [];
+MovieDB.nextRequest = false;
+MovieDB.queue = function(movieDB, fn) {
+  // there might be a pending call to this function
+  clearTimeout(MovieDB.nextRequest);
+
+  // enqueue
+  if (fn) {
+    MovieDB.requestQueue.push(fn);
+  }
+
+  // trim to last maxRate requests
+  while (MovieDB.requestTimes.length > MovieDB.maxRate) {
+    MovieDB.requestTimes.shift();
+  }
+
+  while (
+    (MovieDB.requestCurrent < MovieDB.maxConcurrent) &&
+    ((Date.now() - MovieDB.requestTimes[0]) > MovieDB.maxDuration) &&
+    (MovieDB.requestQueue.length) &&
+    (movieDB.token !== true)
+    ) {
+    // if under limits fire request
+    MovieDB.requestQueue.shift()();
+    MovieDB.requestTimes.push(Date.now());
+    MovieDB.requestCurrent += 1;
+  }
+
+    // no more queued items
+  if (MovieDB.requestQueue.length == 0) {
+    return;
+  } else if (
+    (MovieDB.requestCurrent < MovieDB.maxConcurrent) &&
+    (movieDB.token !== true)
+    ) {
+    // if bound by rate, delay
+    MovieDB.nextRequest = setTimeout(function() {
+      MovieDB.queue(movieDB);
+    }, MovieDB.maxDuration - (Date.now() - MovieDB.requestTimes[0]));
+  } else if (movieDB.token == true) {
+    // waiting for token
+  } else {
+    // waiting for a response to clear
+  }
+};
+
 var execMethod = function(type, params, endpoint, fn){
+  var self = this;
   params = params || {};
   endpoint = endpoint.replace(':id', params.id).replace(':season_number', params.season_number).replace(':episode_number', params.episode_number);
   type = type.toUpperCase();
-  
   var req = request(type, endpoints.base_url + endpoint)
             .query({api_key : this.api_key})
             .set('Accept', 'application/json');
 
-  if(type === 'GET')
-    req.query(params);
-  else
-    req.send(params);
-
-  req.end(function(err, res){
-    if(err){
-      fn(err);
-    } else {
-      fn(null, res.body);
-    }
+  MovieDB.queue(self, function() {
+    if(type === 'GET')
+      req.query(params);
+    else
+      req.send(params);
+    req.end(function(res){
+      //
+      if(res.ok) {
+        fn(null, res.body);
+      } else {
+        fn(res.error, null);
+      }
+      MovieDB.requestCurrent -= 1;
+      MovieDB.queue(self);
+    });
   });
+
+  req.on('error', fn);
 };


### PR DESCRIPTION
Hey mate, I'm a novice and this is my first ever PR, so not sure if these changes are appropriate, but I just thought I'd bring this to your attention anyway.

I was trying to queue calls to tmdb via your moviedb package in my own code, but found that if I send multiple requests to tmdb api in quick succession, your package will just keep sending token requests until the first one is received back from tmdb. So if I send 20 requests, we request 20 tokens, then send the 20 actual requests, and the 40 request quota is exhausted for 10 seconds.

So looking at it the easiest way to fix it was just to move the queuing code I'd written into your package, so it's a fairly big PR but it's been working well for me and adds some cool functionality to your package.

The api for your package, or usage, is exactly the same.. requests are automagically queued if we're either waiting for a token, or waiting for quota.

The queue does a good job of sending the request as soon as you have available quota, rather than just debouncing requests to every 250ms.

I've attached the queue function and info to MovieDB rather than the prototype so that there's only one singleton queue, I couldn't think of a use case for one queue per instance.