### PR TITLE
Add etag and if-modified-since support.

### DIFF
--- a/lib/moviedb.js
+++ b/lib/moviedb.js
@@ -40,8 +40,8 @@ MovieDB.prototype.requestToken = function(fn){
     if(err) {
       fn(err);
     } else {
-       self.token = res.body;
-       fn();
+    self.token = res.body;
+    fn();
     }
   });
 
@@ -85,6 +85,17 @@ var execMethod = function(type, params, endpoint, fn){
   var req = request(type, endpoints.base_url + endpoint)
             .query({api_key : this.api_key})
             .set('Accept', 'application/json');
+  
+  if (params.ifNoneMatch) {
+    req=req.set('If-None-Match', params.ifNoneMatch);
+    
+  } else if (params.ifModifiedSince) {
+    var t=params.ifModifiedSince;
+    if (t.toUTCString) {
+      t=t.toUTCString();
+    }
+    req=req.set('If-Modified-Since', t);
+  }
 
   if(type === 'GET')
     req.query(params);
@@ -93,9 +104,9 @@ var execMethod = function(type, params, endpoint, fn){
 
   req.end(function(err, res){
     if(err){
-      fn(err);
+      fn(err, null, res);
     } else {
-      fn(null, res.body);
+      fn(null, res.body, res);
     }
   });
 };


### PR DESCRIPTION
Add etag and if-modified-since support.  (for http request)
The execMethod() returns a third parameter which is the http response object.
(In order to get the date and the etag header values)

Etag is not supported by the platform (but an issue is still opened)