### PR TITLE
Updated superagent from 2.3.0 to 3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "index.js",
   "author": "Dan Zajdband <dan.zajdband@gmail.com>",
   "dependencies": {
-    "superagent": "^2.3.0"
+    "superagent": "^3.8.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Because of a Denial of Service (DoS) vulnerability in superagent v.2.3.0 it should be updated to path this issue. 

Changes: 
Updated superagent dependency from version 2.3.0 to 3.8.2 in package.json. 