### PR TITLE
Update "superagent" dependency to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "index.js",
   "author": "Dan Zajdband <dan.zajdband@gmail.com>",
   "dependencies": {
-    "superagent": "^2.3.0"
+    "superagent": "^3.7.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
                       === npm audit security report ===


                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance


  Low             Large gzip Denial of Service

  Package         superagent

  Patched in      >=3.7.0

  Dependency of   moviedb

  Path            moviedb > superagent

  More info       https://nodesecurity.io/advisories/479

After updating to 3.7.0 I haven't experienced any issues, nor have I seen any major changes to the structure of superagent.